### PR TITLE
Cut memory usage and remove possibility of accidental data loss.

### DIFF
--- a/sdat2img.py
+++ b/sdat2img.py
@@ -2,10 +2,10 @@
 #encoding:utf8
 #====================================================
 #          FILE: sdat2img.py
-#       AUTHORS: xpirt - luxi78 - howellzhu
-#          DATE: 2015-03-29 14:22:03 CST
+#       AUTHORS: xpirt - luxi78 - howellzhu - joaormatos
+#          DATE: 2015-05-23 19:36:50 UTC
 #====================================================
-import sys, os
+import sys, os, errno
 
 try:
     TRANSFER_LIST_FILE = str(sys.argv[1])
@@ -59,27 +59,40 @@ def parse_transfer_list_file(path):
     trans_list.close()
     return version, new_blocks, erase_block_set, new_block_set
 
-def init_output_file_size(output_file_obj, erase_block_set):
-    max_block_num = max(pair[1] for pair in erase_block_set)
-    output_file_obj.seek(max_block_num*BLOCK_SIZE - 1)
-    output_file_obj.write('\0'.encode('utf-8'))
-    output_file_obj.flush()
-
 def main(argv):
     version, new_blocks, erase_block_set, new_block_set =  parse_transfer_list_file(TRANSFER_LIST_FILE)
-    output_img = open(OUTPUT_IMAGE_FILE, 'wb')
-    init_output_file_size(output_img, erase_block_set)
+
+    # Don't clobber existing files to avoid accidental data loss.
+    try:
+        output_img = open(OUTPUT_IMAGE_FILE, 'wxb')
+    except IOError as e:
+        if e.errno == errno.EEXIST:
+            print('Error: the output file "{}" already exists'.format(e.filename))
+            print('Remove it, rename it, or choose a different file name.')
+            sys.exit(e.errno)
+        else:
+            raise
+
     new_data_file = open(NEW_DATA_FILE, 'rb')
+    max_file_size = max(pair[1] for pair in erase_block_set)*BLOCK_SIZE
 
     for block in new_block_set:
         begin = block[0]
         end = block[1]
         block_count = end - begin
-        print ('Reading %d blocks...' % block_count),
-        data = new_data_file.read(block_count*BLOCK_SIZE)
-        print ('Writing to %d...' % begin),
+        print('Copying {} blocks into position {}...'.format(block_count, begin))
+
+        # Position output file.
         output_img.seek(begin*BLOCK_SIZE)
-        output_img.write(data)
+
+        # Copy one block at a time.
+        while(block_count > 0):
+            output_img.write(new_data_file.read(BLOCK_SIZE))
+            block_count -= 1
+
+    # Make file larger if necessary
+    if(output_img.tell() < max_file_size):
+        output_img.truncate(max_file_size)
 
     output_img.close()
     new_data_file.close()


### PR DESCRIPTION
**About memory usage:**
The previous version read whole chunks into memory and then wrote them to the output file all at once, making the peak memory usage a function of the size of the largest chunk.
In my usage, it peaked at ~130MiB.

By reading and writing BLOCK_SIZE bytes at a time, memory usage stays at a constant low.

**About potential data loss:**
The previous version silently clobbered the output file if it already existed, which could lead to accidental data loss.
The proposed version exits with an error message if the output file already exists.
