### PR TITLE
Allow importing as a module.

### DIFF
--- a/sdat2img.py
+++ b/sdat2img.py
@@ -8,82 +8,62 @@
 
 import sys, os, errno
 
-__version__ = '1.0'
+def main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE):
+    __version__ = '1.0'
 
-if sys.hexversion < 0x02070000:
-    print >> sys.stderr, "Python 2.7 or newer is required."
-    try:
-       input = raw_input
-    except NameError: pass
-    input('Press ENTER to exit...')
-    sys.exit(1)
-else:
-    print('sdat2img binary - version: %s\n' % __version__)
-
-try:
-    TRANSFER_LIST_FILE = str(sys.argv[1])
-    NEW_DATA_FILE = str(sys.argv[2])
-except IndexError:
-    print('\nUsage: sdat2img.py <transfer_list> <system_new_file> [system_img]\n')
-    print('    <transfer_list>: transfer list file')
-    print('    <system_new_file>: system new dat file')
-    print('    [system_img]: output system image\n\n')
-    print('Visit xda thread for more information.\n')
-    try:
-       input = raw_input
-    except NameError: pass
-    input('Press ENTER to exit...')
-    sys.exit()
-
-try:
-    OUTPUT_IMAGE_FILE = str(sys.argv[3])
-except IndexError:
-    OUTPUT_IMAGE_FILE = 'system.img'
-
-BLOCK_SIZE = 4096
-
-def rangeset(src):
-    src_set = src.split(',')
-    num_set =  [int(item) for item in src_set]
-    if len(num_set) != num_set[0]+1:
-        print('Error on parsing following data to rangeset:\n%s' % src)
+    if sys.hexversion < 0x02070000:
+        print >> sys.stderr, "Python 2.7 or newer is required."
+        try:
+            input = raw_input
+        except NameError: pass
+        input('Press ENTER to exit...')
         sys.exit(1)
+    else:
+        print('sdat2img binary - version: %s\n' % __version__)
 
-    return tuple ([ (num_set[i], num_set[i+1]) for i in range(1, len(num_set), 2) ])
+    def rangeset(src):
+        src_set = src.split(',')
+        num_set =  [int(item) for item in src_set]
+        if len(num_set) != num_set[0]+1:
+            print('Error on parsing following data to rangeset:\n%s' % src)
+            sys.exit(1)
 
-def parse_transfer_list_file(path):
-    trans_list = open(TRANSFER_LIST_FILE, 'r')
+        return tuple ([ (num_set[i], num_set[i+1]) for i in range(1, len(num_set), 2) ])
 
-    # First line in transfer list is the version number
-    version = int(trans_list.readline())
+    def parse_transfer_list_file(path):
+        trans_list = open(TRANSFER_LIST_FILE, 'r')
 
-    # Second line in transfer list is the total number of blocks we expect to write
-    new_blocks = int(trans_list.readline())
+        # First line in transfer list is the version number
+        version = int(trans_list.readline())
 
-    if version >= 2:
-        # Third line is how many stash entries are needed simultaneously
-        trans_list.readline()
-        # Fourth line is the maximum number of blocks that will be stashed simultaneously
-        trans_list.readline()
+        # Second line in transfer list is the total number of blocks we expect to write
+        new_blocks = int(trans_list.readline())
 
-    # Subsequent lines are all individual transfer commands
-    commands = []
-    for line in trans_list:
-        line = line.split(' ')
-        cmd = line[0]
-        if cmd in ['erase', 'new', 'zero']:
-            commands.append([cmd, rangeset(line[1])])
-        else:
-            # Skip lines starting with numbers, they are not commands anyway
-            if not cmd[0].isdigit():
-                print('Command "%s" is not valid.' % cmd)
-                trans_list.close()
-                sys.exit(1)
+        if version >= 2:
+            # Third line is how many stash entries are needed simultaneously
+            trans_list.readline()
+            # Fourth line is the maximum number of blocks that will be stashed simultaneously
+            trans_list.readline()
 
-    trans_list.close()
-    return version, new_blocks, commands
+        # Subsequent lines are all individual transfer commands
+        commands = []
+        for line in trans_list:
+            line = line.split(' ')
+            cmd = line[0]
+            if cmd in ['erase', 'new', 'zero']:
+                commands.append([cmd, rangeset(line[1])])
+            else:
+                # Skip lines starting with numbers, they are not commands anyway
+                if not cmd[0].isdigit():
+                    print('Command "%s" is not valid.' % cmd)
+                    trans_list.close()
+                    sys.exit(1)
 
-def main(argv):
+        trans_list.close()
+        return version, new_blocks, commands
+
+    BLOCK_SIZE = 4096
+    
     version, new_blocks, commands = parse_transfer_list_file(TRANSFER_LIST_FILE)
 
     if version == 1:
@@ -139,4 +119,24 @@ def main(argv):
     print('Done! Output image: %s' % os.path.realpath(output_img.name))
 
 if __name__ == '__main__':
-    main(sys.argv)
+    try:
+        TRANSFER_LIST_FILE = str(sys.argv[1])
+        NEW_DATA_FILE = str(sys.argv[2])
+    except IndexError:
+        print('\nUsage: sdat2img.py <transfer_list> <system_new_file> [system_img]\n')
+        print('    <transfer_list>: transfer list file')
+        print('    <system_new_file>: system new dat file')
+        print('    [system_img]: output system image\n\n')
+        print('Visit xda thread for more information.\n')
+        try:
+            input = raw_input
+        except NameError: pass
+        input('Press ENTER to exit...')
+        sys.exit()
+
+    try:
+        OUTPUT_IMAGE_FILE = str(sys.argv[3])
+    except IndexError:
+        OUTPUT_IMAGE_FILE = 'system.img'
+
+    main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE)


### PR DESCRIPTION
Usage is exactly the same when used as a script. Usage as a module works as follows:
```
import sdat2img

sdat2img.main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE)
```