### PR TITLE
1 bugfix, start enforcing consistency for Python 3

### DIFF
--- a/sdat2img.py
+++ b/sdat2img.py
@@ -79,7 +79,7 @@ def main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE):
 
     # Don't clobber existing files to avoid accidental data loss
     try:
-        output_img = open(OUTPUT_IMAGE_FILE, 'wb')
+        output_img = open(OUTPUT_IMAGE_FILE, 'wbx')
     except IOError as e:
         if e.errno == errno.EEXIST:
             print('Error: the output file "{}" already exists'.format(e.filename))

--- a/sdat2img.py
+++ b/sdat2img.py
@@ -6,6 +6,7 @@
 #          DATE: 2018-05-25 10:49:35 CEST
 #====================================================
 
+from __future__ import print_function
 import sys, os, errno
 
 def main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE):
@@ -19,13 +20,13 @@ def main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE):
         input('Press ENTER to exit...')
         sys.exit(1)
     else:
-        print('sdat2img binary - version: %s\n' % __version__)
+        print('sdat2img binary - version: {}\n'.format(__version__))
 
     def rangeset(src):
         src_set = src.split(',')
         num_set =  [int(item) for item in src_set]
         if len(num_set) != num_set[0]+1:
-            print('Error on parsing following data to rangeset:\n%s' % src)
+            print('Error on parsing following data to rangeset:\n{}'.format(src), file=sys.stderr)
             sys.exit(1)
 
         return tuple ([ (num_set[i], num_set[i+1]) for i in range(1, len(num_set), 2) ])
@@ -55,7 +56,7 @@ def main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE):
             else:
                 # Skip lines starting with numbers, they are not commands anyway
                 if not cmd[0].isdigit():
-                    print('Command "%s" is not valid.' % cmd)
+                    print('Command "{}" is not valid.'.format(cmd), file=sys.stderr)
                     trans_list.close()
                     sys.exit(1)
 
@@ -82,8 +83,8 @@ def main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE):
         output_img = open(OUTPUT_IMAGE_FILE, 'wbx')
     except IOError as e:
         if e.errno == errno.EEXIST:
-            print('Error: the output file "{}" already exists'.format(e.filename))
-            print('Remove it, rename it, or choose a different file name.')
+            print('Error: the output file "{}" already exists'.format(e.filename), file=sys.stderr)
+            print('Remove it, rename it, or choose a different file name.', file=sys.stderr)
             sys.exit(e.errno)
         else:
             raise
@@ -108,7 +109,7 @@ def main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE):
                     output_img.write(new_data_file.read(BLOCK_SIZE))
                     block_count -= 1
         else:
-            print('Skipping command %s...' % command[0])
+            print('Skipping command {}...'.format(command[0]))
 
     # Make file larger if necessary
     if(output_img.tell() < max_file_size):
@@ -116,7 +117,7 @@ def main(TRANSFER_LIST_FILE, NEW_DATA_FILE, OUTPUT_IMAGE_FILE):
 
     output_img.close()
     new_data_file.close()
-    print('Done! Output image: %s' % os.path.realpath(output_img.name))
+    print('Done! Output image: {}'.format(os.path.realpath(output_img.name)))
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
The bugfix is in order to avoid overwriting existing files the mode "x" needs to be added.  With mode "wb" opening an existing file succeeds, mode "wbx" fails overwriting.  If this feature is undesired, the extra checking for the condition should be removed so as not make people think this is a bug, rather than a feature.

I've gone through and made all the print() calls consistent.  The documentation recommends using .format() over % so get rid of the uses of %.  Several error messages were going to standard output, instead of standard error, fix these.



FYI pull requests can be handled by `git` itself.  The following command sequence:
```
git remote add tmp https://github.com/ehem/sdat2img.git
git fetch tmp
git merge tmp/master
git remote remove tmp
git push
```
Will have the effect of a pull request without generating an extra merge commit in your history.