### PR TITLE
Add info about brotli compressed images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ This is a simple example on a Linux system:
 If you are looking on decompressing `system.patch.dat` file or `.p` files, therefore reproduce the patching system on your PC, check [imgpatchtools](https://github.com/erfanoabdi/imgpatchtools) out by @erfanoabdi.
 
 
+## Brotli compressed data images
+
+If data image is compressed using [brotli](https://github.com/google/brotli/), decompress the data image (`system.new.dat.br`) and then use the script. Windows users can find brotli binaries [here](https://github.com/google/brotli/releases/tag/v1.0.4). If the image is not converted, mounting the generated system.img will result in error similar to this.
+
+```console
+~$ sudo mount system.img /mnt/lineage
+mount: wrong fs type, bad option, bad superblock on /dev/loop0,
+       missing codepage or helper program, or other error
+       In some cases useful info is found in syslog - try
+       dmesg | tail  or so
+```
+
 
 ## Info
 For more information about this binary, visit http://forum.xda-developers.com/android/software-hacking/how-to-conver-lollipop-dat-files-to-t2978952.


### PR DESCRIPTION
- If data image is compressed using brotli, mounting `system.img` without converting will lead to errors.
- As Python3 is not yet supported with brotli python libraries, just add info to readme for now. 